### PR TITLE
Make it easier to conditionally render subviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ LeapView.extend({
 
 ## Changelog
 
+### 0.7.1
+
+* Setting `view.subviews.foo = false` or returning false from a subview creator now skips on rendering that subview instead of throwing an exception. This is useful if you want to conditionally render some subviews.
+
 ### 0.7.0
 
 * remove dependency on Backbone.Stickit. Leap no longer cares about what dom bindings library is used if any

--- a/view.js
+++ b/view.js
@@ -456,8 +456,9 @@ define(function (require) {
         viewName = view;
         view = this.subviews[viewName];
       }
+      // don't render anything if the subview was set to false
       if (!view) {
-        throw new Error("Subview '" + viewName + "' doesn't exist");
+        return;
       }
 
       // in case of array or object of views clear the container first


### PR DESCRIPTION
Returning false from a subview creator does not render a subview instead of throwing an exception

/cc @roberttod 
