### PR TITLE
Enable subviews to be rendered into .PascalCase classed containers

### DIFF
--- a/view.js
+++ b/view.js
@@ -512,17 +512,32 @@ define(function (require) {
     },
 
     _subviewContainer: function (subviewName) {
-      return this.$(this._subviewNameToSelector(subviewName));
+      return this.$(this._subviewNameToSelector(subviewName)).first();
     },
 
     _subviewNameToSelector: function (subviewName) {
-      return "." + this._subviewNameToClass(subviewName);
+      return _.map([
+        this._subviewNameToClass(subviewName),
+        this._subviewNameToPascalClass(subviewName)
+      ], makeClassString).join(", ");
     },
 
     _subviewNameToClass: function (subviewName) {
       return dashify(subviewName) + "-container";
     },
+
+    _subviewNameToPascalClass: function (subviewName) {
+      return capitalize(subviewName + "Container");
+    }
   });
+
+  function capitalize(str) {
+    return str[0].toUpperCase() + str.slice(1);
+  }
+
+  function makeClassString(str) {
+    return "." + str;
+  }
 
   // loops over each key/value of an object, and if value is array/plainObject, loops
   // over those as well


### PR DESCRIPTION
This enables subviews of a `LeapView` to be rendered into containers with pascal case classes, where no dash case classes exist.

A template would look like this, for example:

``` html
<h1>Some title</h1>
<p>Some paragraph</p>
<div class="SomeSubViewContainer">
  <!-- subview with name 'someSubView' will be rendered here -->
</div>
```

Before, in LeapViews using SuitCSS convention you would end up having to do something like this:

``` html
<h1>Some title</h1>
<p>Some paragraph</p>
<div class="some-sub-view-container">
  <div class="SomeSubView">
    <!-- ... etc -->
  </div>
</div>
```

Which gives you an unnecessary extra wrapper element!
